### PR TITLE
Stop player tick mixin from cancelling

### DIFF
--- a/src/main/java/me/luligabi/miningutility/mixin/PlayerEntityMixin.java
+++ b/src/main/java/me/luligabi/miningutility/mixin/PlayerEntityMixin.java
@@ -10,10 +10,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(PlayerEntity.class)
 public class PlayerEntityMixin {
 
-    @Inject(method = "tick", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "tick", at = @At("RETURN"))
     public void injectTick(CallbackInfo info) {
         PlayerEntity playerEntity = ((PlayerEntity) (Object) this);
         PlayerEntityHook.tick(playerEntity, 11*20);
-        info.cancel();
     }
 }


### PR DESCRIPTION
Why is it cancelled in the first place?